### PR TITLE
웨폰데이터 값 밸런스 조정

### DIFF
--- a/Assets/Scripts/Weapons-newScript/SlashProjectile.cs
+++ b/Assets/Scripts/Weapons-newScript/SlashProjectile.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using UnityEditor.Localization.Plugins.XLIFF.V20;
 using UnityEngine;
+using UnityEngine.UIElements;
 
 public class SlashProjectile : ProjectileBase
 {
@@ -43,6 +45,7 @@ public class SlashProjectile : ProjectileBase
         timer = 0f;
         hitTargets.Clear();
         baseRotation = Quaternion.LookRotation(direction);
+        transform.localScale = Vector3.one * data.size;
         transform.rotation = baseRotation * Quaternion.Euler(0f, -swingAngle * 0.5f, 0f);
         if (owner != null)
         {
@@ -62,7 +65,7 @@ public class SlashProjectile : ProjectileBase
 
         float t = timer / lifeTime;
         float angle = Mathf.Lerp(-swingAngle * 0.5f, swingAngle * 0.5f, t);
-
+        
         transform.rotation = baseRotation * Quaternion.Euler(0f, angle, 0f);
         transform.position = owner.position + transform.forward * radius;
 

--- a/Assets/WeaponData/ElectronicStaff.asset
+++ b/Assets/WeaponData/ElectronicStaff.asset
@@ -14,14 +14,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WeaponData
   weaponName: "\uC77C\uB809\uD2B8\uB85C\uB2C9\uC2A4\uD0DC\uD504"
   icon: {fileID: 21300000, guid: b50bd53042605474a9e62915b783e7ad, type: 3}
-  damage: 15
+  damage: 20
   projectileSpeed: 0
   size: 0
-  range: 7
+  range: 15
   cooldown: 2
   projectileCount: 5
   maxLevel: 8
   existTime: 0
+  knockBack: 0
   Description: "\uC801\uB4E4\uC5D0\uAC8C \uD37C\uC9C0\uB294 \uC804\uAE30\uACF5\uACA9"
   levelStats:
   - modifiers:

--- a/Assets/WeaponData/Molotov.asset
+++ b/Assets/WeaponData/Molotov.asset
@@ -14,14 +14,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WeaponData
   weaponName: "\uD654\uC5FC\uBCD1"
   icon: {fileID: 21300000, guid: 10074011650a8504780fc243b0d61250, type: 3}
-  damage: 1000
+  damage: 35
   projectileSpeed: 0
   size: 4
   range: 0
   cooldown: 4
   projectileCount: 1
   maxLevel: 8
-  existTime: 3
+  existTime: 5
+  knockBack: 0
   Description: "\uD654\uC5FC\uBCD1\uC744 \uB358\uC9D1\uB2C8\uB2E4"
   levelStats:
   - modifiers:

--- a/Assets/WeaponData/ShotGun.asset
+++ b/Assets/WeaponData/ShotGun.asset
@@ -14,15 +14,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WeaponData
   weaponName: "\uC0F7\uAC74"
   icon: {fileID: 21300000, guid: a67c2f4e5edd9e843aca860c5d563fca, type: 3}
-  damage: 10
+  damage: 20
   projectileSpeed: 30
   size: 5
   range: 30
-  cooldown: 1
+  cooldown: 2
   projectileCount: 3
   maxLevel: 5
   existTime: 0
-  knockBack: 0
+  knockBack: 0.3
   Description: "\uC720\uD0C4\uC744 \uC7A5\uCC29\uD55C \uC0F7\uAC74 \uBC1C\uC0AC"
   levelStats:
   - modifiers:
@@ -44,11 +44,11 @@ MonoBehaviour:
     types: 0b0000000d000000
     description: "\uD22C\uC0AC\uCCB4 \uC218 \uC99D\uAC00"
   - modifiers:
-    - type: 1
+    - type: 0
       category: 0
-      value: 0.2
-    types: 04000000
-    description: "\uACF5\uACA9\uB825\uC99D\uAC00"
+      value: 1
+    types: 0b000000
+    description: "\uD22C\uC0AC\uCCB4 \uC218 \uC99D\uAC00"
   - modifiers:
     - type: 0
       category: 0

--- a/Assets/WeaponData/Shuriken.asset
+++ b/Assets/WeaponData/Shuriken.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WeaponData
   weaponName: "\uC218\uB9AC\uAC80"
   icon: {fileID: 21300000, guid: 19ebf32e7167c7e4f98272a1a62ed77b, type: 3}
-  damage: 10
+  damage: 20
   projectileSpeed: 180
   size: 1
   range: 3
@@ -22,7 +22,8 @@ MonoBehaviour:
   projectileCount: 1
   maxLevel: 8
   existTime: 5
-  Description: 
+  knockBack: 0
+  Description: "\uACF5\uC804\uD615 \uC218\uB9AC\uAC80 \uD68C\uC804\uACF5\uACA9"
   levelStats:
   - modifiers:
     - type: 0
@@ -61,8 +62,8 @@ MonoBehaviour:
     types: 0d000000
     description: "\uD68C\uC804 \uBC94\uC704 \uC99D\uAC00"
   - modifiers:
-    - type: 0
-      category: 1
+    - type: 1
+      category: 0
       value: 2
     types: 0b000000
     description: "[MAX]\uC218\uB9AC\uAC80 \uC218 \uB300\uB7C9 \uC99D\uAC00"

--- a/Assets/WeaponData/Slasher.asset
+++ b/Assets/WeaponData/Slasher.asset
@@ -16,53 +16,54 @@ MonoBehaviour:
   icon: {fileID: 21300000, guid: f63ae385b7aaa5a4fb5f4241c5909e4a, type: 3}
   damage: 30
   projectileSpeed: 0
-  size: 1
+  size: 5
   range: 30
   cooldown: 1
   projectileCount: 1
   maxLevel: 8
   existTime: 0
-  Description: 
+  knockBack: 0
+  Description: "\uADFC\uC811\uD615 \uAC80 \uACF5\uACA9"
   levelStats:
-  - modifiers:
-    - type: 0
-      category: 0
-      value: 10
-    types: 04000000
-    description: "\uACF5\uACA9\uB825 \uC99D\uAC00"
-  - modifiers:
-    - type: 0
-      category: 0
-      value: 0
-    types: 04000000
-    description: "\uACF5\uACA9\uB825 \uC99D\uAC00"
-  - modifiers:
-    - type: 0
-      category: 0
-      value: 0
-    types: 04000000
-    description: "\uACF5\uACA9\uB825 \uC99D\uAC00"
-  - modifiers:
-    - type: 0
-      category: 0
-      value: 0
-    types: 04000000
-    description: "\uACF5\uACA9\uB825 \uC99D\uAC00"
-  - modifiers:
-    - type: 0
-      category: 0
-      value: 0
-    types: 04000000
-    description: "\uACF5\uACA9\uB825 \uC99D\uAC00"
   - modifiers:
     - type: 0
       category: 0
       value: -0.2
     types: 07000000
-    description: "\uACF5\uACA9\uC18D\uB3C4 \uC99D\uAC00"
+    description: "\uACF5\uACA9 \uC18D\uB3C4 \uC99D\uAC00"
+  - modifiers:
+    - type: 1
+      category: 0
+      value: 0.2
+    types: 06000000
+    description: "\uACF5\uACA9\uBC94\uC704\uC99D\uAC00"
   - modifiers:
     - type: 0
       category: 0
       value: 10
-    types: 00000000
+    types: 04000000
     description: "\uACF5\uACA9\uB825 \uC99D\uAC00"
+  - modifiers:
+    - type: 0
+      category: 0
+      value: 10
+    types: 04000000
+    description: "\uACF5\uACA9\uB825 \uC99D\uAC00"
+  - modifiers:
+    - type: 0
+      category: 0
+      value: 0
+    types: 04000000
+    description: "\uACF5\uACA9\uB825 \uC99D\uAC00"
+  - modifiers:
+    - type: 1
+      category: 0
+      value: 0.3
+    types: 06000000
+    description: "\uACF5\uACA9\uBC94\uC704 \uC99D\uAC00"
+  - modifiers:
+    - type: 0
+      category: 0
+      value: -0.3
+    types: 07000000
+    description: "\uACF5\uACA9\uC18D\uB3C4 \uB300\uD3ED\uC99D\uAC00"


### PR DESCRIPTION
샷건 공격 쿨타임 2배증가( 공속감소), 데미지 증가 및 약간의 넉백효과 추가
일렉트로닉 스태프 : 데미지 약간 증가 및 반응 사거리 증가(Range, Damage)
화염병 : 비정상적인 데미지로 구현되어있어서 데미지를 줄이고, 생성후 지속시간 증가(쿨타임보다 1~2초 정도길게 소환됨)
수리검 : 데미지 소폭증가 (1레벨때 효율 감안)
